### PR TITLE
Add more contrast to files and folders in the sidebar that have been added to .gitignore

### DIFF
--- a/themes/colors.yaml
+++ b/themes/colors.yaml
@@ -56,6 +56,7 @@ _transparent: '#00000000'
 _git-modified: '#FFCC95' # light-orange
 _git-added: '#19f9d8' # green
 _git-removed: '#FF4B82' # light-red
+_git-ignored: '#757575' # light-grey
 # Linter Colors
 _error: '#FF4B82' # light-red
 _warning: '#FFCC95' # light-orange

--- a/themes/workbench.yaml
+++ b/themes/workbench.yaml
@@ -123,6 +123,10 @@ colors:
   editorGutter.addedBackground: _git-added
   editorGutter.deletedBackground: _git-removed
   # -----------------------------------------------------------------------------
+  # Git Decoration
+  # -----------------------------------------------------------------------------
+  gitDecoration.ignoredResourceForeground: _git-ignored
+  # -----------------------------------------------------------------------------
   # List
   # -----------------------------------------------------------------------------
   # List elements are inside the sidebar + command dropdown


### PR DESCRIPTION
The current version of this theme does not change the color of the `.gitignore`'d files. The default theme's color for these items is not contrasting enough to be able to see a difference.

This PR adds a new `_git-ignored` color based on `_light-grey` (`#757575`) and sets the `gitDecoration.ignoredResourceForeground` color to that.

Before:
![screenshot_111](https://user-images.githubusercontent.com/1687902/36861683-9d197458-1d52-11e8-8ca2-9fe8fb0e12a3.jpg)

After:
![screenshot_110](https://user-images.githubusercontent.com/1687902/36861695-a46fe64c-1d52-11e8-91ef-c831230d785a.jpg)
