### PR TITLE
Fix XML syntax colors

### DIFF
--- a/themes/html.yaml
+++ b/themes/html.yaml
@@ -8,3 +8,7 @@
 - scope: entity.name.tag.inline.any.html, entity.name.tag.other.html, entity.name.tag.block.any.html, entity.name.tag.localname.xml
   settings:
     foreground: _red
+
+- scope: entity.name.tag.xml, meta.tag.xml
+  settings:
+    foreground: _red


### PR DESCRIPTION
Better XML syntax colors

<img width="786" alt="screen shot 2018-06-30 at 4 52 20 pm" src="https://user-images.githubusercontent.com/10458061/42124157-eff6b1ec-7c87-11e8-9286-08cec74a6460.png">
