### PR TITLE
Additional syntax: type name, misc keywords.

### DIFF
--- a/dist/Panda.json
+++ b/dist/Panda.json
@@ -37,6 +37,12 @@
       }
     },
     {
+      "scope": "keyword.operator.misc, keyword.operator.sigil",
+      "settings": {
+        "foreground": "#FF75B5"
+      }
+    },
+    {
       "scope": "storage",
       "settings": {
         "foreground": "#FFB86C"
@@ -190,6 +196,13 @@
       "scope": "variable.interpolation",
       "settings": {
         "foreground": "#FF75B5"
+      }
+    },
+    {
+      "scope": "entity.name.type",
+      "settings": {
+        "foreground": "#19f9d8",
+        "fontStyle": "italic"
       }
     },
     {
@@ -592,9 +605,9 @@
     "extensionButton.prominentBackground": "#45A9F9",
     "extensionButton.prominentHoverBackground": "#676B79",
     "editorError.foreground": "#FF4B82",
-    "editorError.border": "#FF4B82",
+    "editorError.border": "#292A2B",
     "editorWarning.foreground": "#FFCC95",
-    "editorWarning.border": "#FFCC95",
+    "editorWarning.border": "#292A2B",
     "editorGutter.modifiedBackground": "#FFCC95",
     "editorGutter.addedBackground": "#19f9d8",
     "editorGutter.deletedBackground": "#FF4B82",

--- a/themes/panda-base.yaml
+++ b/themes/panda-base.yaml
@@ -35,6 +35,10 @@ tokenColors:
 - scope: keyword.operator.logical, keyword.operator.comparison
   settings:
     foreground: _light-orange
+# Make Rust operators pink: &, ::, =>, etc.
+- scope: keyword.operator.misc, keyword.operator.sigil
+  settings:
+    foreground: _pink
 
 # -----------------------------------------------------------------------------
 # Storage
@@ -190,3 +194,12 @@ tokenColors:
 - scope: variable.interpolation
   settings:
     foreground: _pink
+
+# -----------------------------------------------------------------------------
+# Name of type (struct, class, etc.)
+# -----------------------------------------------------------------------------
+# Generic name of type match
+- scope: entity.name.type
+  settings:
+    foreground: _green
+    fontStyle: italic


### PR DESCRIPTION
Inspired with the standard Monokai theme (and other well-supported) which recognizes a lot of additional syntax. Tested on Rust, C, Yaml.

**No colors changed**! Only **additional** tokens are colorized.

![image](https://user-images.githubusercontent.com/5967447/79027991-0c02a700-7b97-11ea-8698-8b8e8d3b6c13.png)
