### PR TITLE
Make whitespace foreground less contrast.

### DIFF
--- a/dist/Panda.json
+++ b/dist/Panda.json
@@ -581,7 +581,7 @@
     "editorRuler.foreground": "#B084EB60",
     "editorBracketMatch.border": "#19f9d8",
     "editorCodeLens.foreground": "#FFB86C40",
-    "editorWhitespace.foreground": "#4E5260",
+    "editorWhitespace.foreground": "#3E4250",
     "editor.selectionBackground": "#FFB86C40",
     "editor.inactiveSelectionBackground": "#FFB86C40",
     "editor.selectionHighlightBackground": "#FFB86C40",

--- a/themes/colors.yaml
+++ b/themes/colors.yaml
@@ -8,7 +8,7 @@ _lighter-gray-fade: '#CDCDCD30'
 _contrast-gray: '#BBBBBB'
 _light-gray: '#757575'
 _light-midnight: '#676B79'
-_steel-gray: '#4E5260'
+_steel-gray: '#3E4250'
 _gray: '#373B41'
 _gray-fade: '#373B4199'
 _seal: '#31353a' # Light background


### PR DESCRIPTION
Problem: comment and whitespace have almost the same contrast (comparing to background) making it heavy to distinguish.

Measure: "Shadowed" `_steel-gray` color which is used solely to render whitespaces.

![image](https://user-images.githubusercontent.com/5967447/79114797-e0491200-7d8c-11ea-8a4e-fc52e3da9d46.png)

Basically, comments are ok (may be too dimmed in my opinion) until you enable whitespace rendering, in that case comments are heavily mixed with rendered whitespaces and vertical lines. So I propose to dim whitespaces a bit, it would be safe for overall Panda experience.