### PR TITLE
Add missing scope "variable.other.enummember"

### DIFF
--- a/dist/Panda.json
+++ b/dist/Panda.json
@@ -55,6 +55,12 @@
       }
     },
     {
+      "scope": "variable.other.enummember",
+      "settings": {
+        "foreground": "#FFB86C",
+      }
+    },
+    {
       "scope": "constant.character.escape",
       "settings": {
         "foreground": "#45A9F9"

--- a/themes/panda-base.yaml
+++ b/themes/panda-base.yaml
@@ -55,6 +55,11 @@ tokenColors:
 - scope: constant
   settings:
     foreground: _orange
+# Makes enum members same as constant
+# Follow the official theme Light (Visual Studio) & Dark (Visual Studio)
+- scope: variable.other.enummember
+  settings:
+    foreground: _orange
 # Makes true/false booleans, null, undefined blue
 # - scope: constant.language
 #   settings:


### PR DESCRIPTION
Follow official theme Light (Visual Studio) and Dark (Visual Studio)

The scope `variable.other.enummember` is used by Rust enum members

Example:

```rust
fn return_one_hundred() -> Result<i32, Error> {
    Ok(100)
}
```

The `Ok` here is enum members of enum `std::result::Result`

Ref: https://doc.rust-lang.org/std/result/enum.Result.html